### PR TITLE
fix: using promise and opts on useMemo dependencies array

### DIFF
--- a/packages/react/src/usePromise.js
+++ b/packages/react/src/usePromise.js
@@ -6,7 +6,7 @@ import { useStateRx } from './useStateRx'
 export const usePromise = (promise, { lazy, ...opts } = {}) => {
 	const [rxState, dispatch, ...meta] = useMemo(
 		() => control(promise, { ...opts, lazy: true }),
-		[]
+		[promise, opts]
 	)
 
 	const [state] = useStateRx(rxState)


### PR DESCRIPTION
# Adjust Use Promise

When using `useFetch` inside a test file, we discovered that the `useMemo` inside `usePromise` function does not work as expected that's because his dependency array was empty.

We solved this by added `promise` and `opts`  props to this array.

With this fix we should be able to test `useFetch`!

Maybe you can check [this video](https://www.youtube.com/watch?v=RZG0iRfUaY0&t=4s) about how to use useMemo correctly.

